### PR TITLE
Update command.py

### DIFF
--- a/pygna/command.py
+++ b/pygna/command.py
@@ -84,6 +84,7 @@ def test_topology_total_degree(
     size_cut: "removes all genesets with a mapped length < size_cut" = 20,
     number_of_permutations: "number of permutations for computing the empirical pvalue" = 500,
     cores: "Number of cores for the multiprocessing" = 1,
+    n_bins: 'if >1 applies degree correction by binning the node degrees and sampling according to geneset distribution' = 1,
     results_figure: "barplot of results, use pdf or png extension" = None,
     diagnostic_null_folder: "plot null distribution, pass the folder where all the figures are going to be saved "
                             "(one for each dataset)" = None):


### PR DESCRIPTION
The line that defines n_bins is missing in the function definition of test_topology_total_degree and results in n_bins not defined error while running the command as you can see in the image below:
![Screenshot_from_2021-12-07_15-37-03](https://user-images.githubusercontent.com/82365863/147738937-915b755b-d025-4bac-9aea-4fe4971b4825.png)
I added the line, and it works, so I am sending this pull request.
![image](https://user-images.githubusercontent.com/82365863/147739527-fca8dff6-7dfe-40a6-bbb8-3f3910ab5013.png)

